### PR TITLE
RuleId is used as issue title if not provided

### DIFF
--- a/src/CodeReview.FileConverter/Services/RoslynIssueConverter.cs
+++ b/src/CodeReview.FileConverter/Services/RoslynIssueConverter.cs
@@ -55,7 +55,7 @@ namespace GodelTech.CodeReview.FileConverter.Services
                 Description = diagnosticDetails?.Description,
                 DetailsUrl = diagnosticDetails?.HelpLinkUri,
                 Id = _idGenerator.GetNext(),
-                Title = diagnosticDetails?.Title,
+                Title = diagnosticDetails?.Title ?? issue.RuleId,
                 Tags = diagnosticDetails?.CustomTags,
                 Level = ConvertLevel(issue.Level),
                 Message = issue.Message,


### PR DESCRIPTION
+semver:patch

#### CHANGE TYPE
<!--- MANDATORY: Delete the items that don't apply -->
 - [x] Patch

#### GITHUB ISSUE LINK
Title is mandatory property. When Roslyn dictionary doesn't contain information about issue empty title is produced. It was decided to use RuleId as default value in order to avoid empty titles.